### PR TITLE
Adding LM Studio local AI, Save reminder dialog, fixing SteamCMD path customization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asa-server-manager",
-  "version": "4.5.5",
+  "version": "4.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asa-server-manager",
-      "version": "4.5.5",
+      "version": "4.6.2",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
         "@hello-pangea/dnd": "^18.0.1",
@@ -1382,9 +1382,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,9 +1396,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,9 +1410,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,9 +1424,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,9 +1438,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,9 +1452,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1484,9 +1466,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1501,9 +1480,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1518,9 +1494,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1535,9 +1508,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1552,9 +1522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1569,9 +1536,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1586,9 +1550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1838,9 +1799,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1858,9 +1816,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1878,9 +1833,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1898,9 +1850,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1918,9 +1867,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -495,35 +495,86 @@ fn get_tool_definitions() -> serde_json::Value {
     ])
 }
 
+// ── Provider Resolution ────────────────────────────────────────────────
+
+/// Resolved endpoint config for the active AI provider.
+struct AiProviderConfig {
+    /// Full chat-completions endpoint URL.
+    endpoint: String,
+    /// Bearer token, if the provider requires auth. LM Studio typically does not.
+    api_key: Option<String>,
+    /// Effective model id to send in the request body.
+    model: String,
+}
+
+/// Normalizes an OpenAI-compatible base URL to a `/chat/completions` endpoint.
+/// Accepts either a bare base ("http://localhost:1234/v1") or a full endpoint.
+fn build_openai_endpoint(base: &str) -> String {
+    let trimmed = base.trim().trim_end_matches('/');
+    if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else {
+        format!("{}/chat/completions", trimmed)
+    }
+}
+
+/// Resolves the AI provider config from the settings DB.
+///
+/// - `nvidia` (default): NVIDIA NIM cloud API, requires `nvidia_api_key`.
+/// - `lmstudio`: local LM Studio (OpenAI-compatible) server at `lmstudio_base_url`.
+///   API key is optional; the custom loaded model name (`lmstudio_model`) overrides
+///   the requested model when set.
+fn resolve_ai_config(
+    state: &tauri::State<'_, AppState>,
+    requested_model: String,
+) -> Result<AiProviderConfig, String> {
+    let db = state.db.lock().map_err(|e| format!("DB lock failed: {}", e))?;
+
+    let get = |key: &str| -> Option<String> {
+        db.get_setting(key).ok().flatten().filter(|v| !v.trim().is_empty())
+    };
+
+    let provider = get("ai_provider").unwrap_or_else(|| "nvidia".to_string());
+
+    match provider.as_str() {
+        "lmstudio" => {
+            let base = get("lmstudio_base_url")
+                .unwrap_or_else(|| "http://localhost:1234/v1".to_string());
+            // Custom loaded model takes precedence; fall back to whatever the UI passed.
+            let model = get("lmstudio_model").unwrap_or(requested_model);
+            Ok(AiProviderConfig {
+                endpoint: build_openai_endpoint(&base),
+                api_key: get("lmstudio_api_key"),
+                model,
+            })
+        }
+        _ => {
+            let api_key = get("nvidia_api_key").ok_or_else(|| {
+                "NVIDIA API key not configured. Add it in Settings → API Keys.".to_string()
+            })?;
+            Ok(AiProviderConfig {
+                endpoint: "https://integrate.api.nvidia.com/v1/chat/completions".to_string(),
+                api_key: Some(api_key),
+                model: requested_model,
+            })
+        }
+    }
+}
+
 // ── Commands ───────────────────────────────────────────────────────────
 
-/// Non-streaming AI chat — sends messages to NVIDIA API and returns full response
+/// Non-streaming AI chat — sends messages to the configured provider and returns full response
 #[tauri::command]
 pub async fn ai_chat(
     state: tauri::State<'_, AppState>,
     messages: Vec<AiMessage>,
     model: String,
 ) -> Result<AiResponse, String> {
-    // Read API key from settings DB
-    let api_key = {
-        let db = state.db.lock().map_err(|e| format!("DB lock failed: {}", e))?;
-        let conn = db.get_connection().map_err(|e| format!("DB connection failed: {}", e))?;
-        let mut stmt = conn
-            .prepare("SELECT value FROM settings WHERE key = 'nvidia_api_key'")
-            .map_err(|e| format!("DB query failed: {}", e))?;
-        let key: Option<String> = stmt
-            .query_row([], |row| row.get(0))
-            .ok();
-        key
-    };
-
-    let api_key = api_key
-        .filter(|k| !k.trim().is_empty())
-        .ok_or_else(|| "NVIDIA API key not configured. Add it in Settings → API Keys.".to_string())?;
+    let config = resolve_ai_config(&state, model)?;
 
     // Build request body
     let body = serde_json::json!({
-        "model": model,
+        "model": config.model,
         "messages": messages,
         "tools": get_tool_definitions(),
         "tool_choice": "auto",
@@ -532,11 +583,14 @@ pub async fn ai_chat(
     });
 
     let client = reqwest::Client::new();
-    let response = client
-        .post("https://integrate.api.nvidia.com/v1/chat/completions")
-        .header("Authorization", format!("Bearer {}", api_key))
+    let mut req = client
+        .post(&config.endpoint)
         .header("Content-Type", "application/json")
-        .json(&body)
+        .json(&body);
+    if let Some(key) = &config.api_key {
+        req = req.header("Authorization", format!("Bearer {}", key));
+    }
+    let response = req
         .send()
         .await
         .map_err(|e| format!("API request failed: {}", e))?;
@@ -592,25 +646,10 @@ pub async fn ai_chat_stream(
     messages: Vec<AiMessage>,
     model: String,
 ) -> Result<(), String> {
-    // Read API key from settings DB
-    let api_key = {
-        let db = state.db.lock().map_err(|e| format!("DB lock failed: {}", e))?;
-        let conn = db.get_connection().map_err(|e| format!("DB connection failed: {}", e))?;
-        let mut stmt = conn
-            .prepare("SELECT value FROM settings WHERE key = 'nvidia_api_key'")
-            .map_err(|e| format!("DB query failed: {}", e))?;
-        let key: Option<String> = stmt
-            .query_row([], |row| row.get(0))
-            .ok();
-        key
-    };
-
-    let api_key = api_key
-        .filter(|k| !k.trim().is_empty())
-        .ok_or_else(|| "NVIDIA API key not configured. Add it in Settings → API Keys.".to_string())?;
+    let config = resolve_ai_config(&state, model)?;
 
     let body = serde_json::json!({
-        "model": model,
+        "model": config.model,
         "messages": messages,
         "temperature": 0.7,
         "max_tokens": 4096,
@@ -618,11 +657,14 @@ pub async fn ai_chat_stream(
     });
 
     let client = reqwest::Client::new();
-    let response = client
-        .post("https://integrate.api.nvidia.com/v1/chat/completions")
-        .header("Authorization", format!("Bearer {}", api_key))
+    let mut req = client
+        .post(&config.endpoint)
         .header("Content-Type", "application/json")
-        .json(&body)
+        .json(&body);
+    if let Some(key) = &config.api_key {
+        req = req.header("Authorization", format!("Bearer {}", key));
+    }
+    let response = req
         .send()
         .await
         .map_err(|e| format!("API request failed: {}", e))?;
@@ -689,4 +731,61 @@ pub async fn ai_chat_stream(
     });
 
     Ok(())
+}
+
+/// Lists models currently loaded/available on an LM Studio (or any OpenAI-compatible)
+/// server. Used by Settings to detect the custom loaded model and verify connectivity.
+/// `base_url` is optional — falls back to the saved `lmstudio_base_url` setting.
+#[tauri::command]
+pub async fn lmstudio_list_models(
+    state: tauri::State<'_, AppState>,
+    base_url: Option<String>,
+) -> Result<Vec<String>, String> {
+    let (base, api_key) = {
+        let db = state.db.lock().map_err(|e| format!("DB lock failed: {}", e))?;
+        let get = |key: &str| -> Option<String> {
+            db.get_setting(key).ok().flatten().filter(|v| !v.trim().is_empty())
+        };
+        let base = base_url
+            .filter(|b| !b.trim().is_empty())
+            .or_else(|| get("lmstudio_base_url"))
+            .unwrap_or_else(|| "http://localhost:1234/v1".to_string());
+        (base, get("lmstudio_api_key"))
+    };
+
+    let url = format!("{}/models", base.trim().trim_end_matches('/'));
+
+    let client = reqwest::Client::new();
+    let mut req = client.get(&url);
+    if let Some(key) = &api_key {
+        req = req.header("Authorization", format!("Bearer {}", key));
+    }
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach LM Studio at {}: {}", url, e))?;
+
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!("LM Studio error ({}): {}", status, text));
+    }
+
+    let parsed: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("Failed to parse models response: {}", e))?;
+
+    let models = parsed["data"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| m["id"].as_str().map(|s| s.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Ok(models)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -756,6 +756,7 @@ pub fn run(safe_mode: bool) -> tauri::Result<()> {
              // AI Agent Commands
              commands::ai::ai_chat,
              commands::ai::ai_chat_stream,
+             commands::ai::lmstudio_list_models,
 
              // Tribe Log Commands
               commands::tribe_log::get_tribe_logs,

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -45,9 +45,23 @@ pub fn resolve_steamcmd_dir(
     app_handle: &tauri::AppHandle,
 ) -> Result<PathBuf, String> {
     if let Ok(Some(custom_path)) = db.get_setting("custom_steamcmd_path") {
-        let trimmed = custom_path.trim();
+        // Strip surrounding quotes/whitespace that can slip in from manual entry.
+        let trimmed = custom_path.trim().trim_matches('"').trim();
         if !trimmed.is_empty() {
-            return Ok(PathBuf::from(trimmed));
+            let p = PathBuf::from(trimmed);
+            // The setting is meant to be a folder. If the user pointed it directly
+            // at steamcmd.exe (or any file), use its parent directory instead.
+            let is_exe = p
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.eq_ignore_ascii_case("steamcmd.exe"))
+                .unwrap_or(false);
+            if is_exe || p.is_file() {
+                if let Some(parent) = p.parent() {
+                    return Ok(parent.to_path_buf());
+                }
+            }
+            return Ok(p);
         }
     }
 

--- a/src-tauri/src/services/server_installer.rs
+++ b/src-tauri/src/services/server_installer.rs
@@ -216,12 +216,36 @@ impl ServerInstaller {
         };
         let steamcmd_exe = steamcmd_dir.join("steamcmd.exe");
 
+        // Self-heal: if SteamCMD isn't present in the resolved (possibly custom)
+        // folder, provision it there now instead of failing. This covers the case
+        // where the user set a custom SteamCMD path that hasn't been populated yet.
         if !steamcmd_exe.exists() {
             self.emit_console(
-                "SteamCMD not found! Please install SteamCMD first.",
-                "error",
+                &format!(
+                    "SteamCMD not found in {}. Downloading and installing it now...",
+                    steamcmd_dir.display()
+                ),
+                "info",
             );
-            return Err("SteamCMD not installed".to_string());
+            let provisioner = crate::services::steamcmd::SteamCmdService::with_custom_dir(
+                self.app_handle.clone(),
+                steamcmd_dir.clone(),
+            );
+            if let Err(e) = provisioner.install().await {
+                self.emit_console(
+                    &format!("Failed to install SteamCMD automatically: {}", e),
+                    "error",
+                );
+                return Err(format!("SteamCMD installation failed: {}", e));
+            }
+            if !steamcmd_exe.exists() {
+                self.emit_console(
+                    "SteamCMD installation completed but steamcmd.exe is still missing.",
+                    "error",
+                );
+                return Err("SteamCMD not installed".to_string());
+            }
+            self.emit_console("SteamCMD installed successfully.", "success");
         }
 
         self.emit_console(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,11 @@ const IndexRedirect = () => {
     return <Navigate to={activeGame === 'ASE' ? "/ase/dashboard" : "/dashboard"} replace />;
 };
 
-// Root layout wraps the app shell in an error boundary + Suspense for lazy pages.
+/**
+ * Root route element: wraps the persistent app shell (`AppLayout`) in an error
+ * boundary and a Suspense boundary so lazily-loaded pages show the loader while
+ * their chunks download.
+ */
 const RootLayout = () => (
     <ErrorBoundary>
         <Suspense fallback={<PageLoader />}>
@@ -87,7 +91,11 @@ const RootLayout = () => (
     </ErrorBoundary>
 );
 
-// Data router (createBrowserRouter) enables useBlocker for unsaved-changes guards.
+/**
+ * Application data router. A data router (`createBrowserRouter`) is required for
+ * `useBlocker`, which the Settings page uses to guard against navigating away
+ * with unsaved changes. Holds the full ASA + ASE route tree under `RootLayout`.
+ */
 const router = createBrowserRouter(
     createRoutesFromElements(
         <Route path="/" element={<RootLayout />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, Suspense, lazy, useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { createBrowserRouter, createRoutesFromElements, Route, RouterProvider, Navigate } from 'react-router-dom';
 import AppLayout from './components/layout/AppLayout';
 import WelcomeOverlay from './components/layout/WelcomeOverlay';
 import UpdateChecker from './components/UpdateChecker';
@@ -78,6 +78,75 @@ const IndexRedirect = () => {
     return <Navigate to={activeGame === 'ASE' ? "/ase/dashboard" : "/dashboard"} replace />;
 };
 
+// Root layout wraps the app shell in an error boundary + Suspense for lazy pages.
+const RootLayout = () => (
+    <ErrorBoundary>
+        <Suspense fallback={<PageLoader />}>
+            <AppLayout />
+        </Suspense>
+    </ErrorBoundary>
+);
+
+// Data router (createBrowserRouter) enables useBlocker for unsaved-changes guards.
+const router = createBrowserRouter(
+    createRoutesFromElements(
+        <Route path="/" element={<RootLayout />}>
+            <Route index element={<IndexRedirect />} />
+            <Route path="dashboard" element={<Dashboard />} />
+            <Route path="servers" element={<ServerManager />} />
+            <Route path="mods" element={<ModManager />} />
+            <Route path="config" element={<ConfigEditor />} />
+            <Route path="clusters" element={<ClusterManager />} />
+            <Route path="backups" element={<Backups />} />
+            <Route path="autosaves" element={<AutoSaves />} />
+            <Route path="rcon" element={<RconConsole />} />
+            <Route path="scheduler" element={<Scheduler />} />
+            <Route path="logs" element={<LogsConsole />} />
+            <Route path="tools/advanced" element={<AdvancedPage />} />
+            <Route path="tools/discord" element={<DiscordBot />} />
+            <Route path="tools/discord-control" element={<DiscordControlPanel />} />
+            <Route path="tools/plugins" element={<PluginManager />} />
+            <Route path="tools/chat-translator" element={<ChatTranslator />} />
+            <Route path="tools/combat-metrics" element={<CombatMetrics />} />
+            <Route path="tools/files" element={<FileManager />} />
+            <Route path="tools/ai" element={<AIAssistant />} />
+            <Route path="tools/tribe-logs" element={<TribeLogViewer />} />
+            <Route path="tools/upnp" element={<UPnPPanel />} />
+            <Route path="tools/organization" element={<ServerOrganization />} />
+            <Route path="tools/boost" element={<BoostManager />} />
+            <Route path="hardware" element={<Hardware />} />
+            <Route path="wiki" element={<Wiki />} />
+            <Route path="settings" element={<Settings />} />
+
+            {/* ASE Module Routes */}
+            <Route path="ase/dashboard" element={<ASEDashboard />} />
+            <Route path="ase/servers" element={<ASEServerManager />} />
+            <Route path="ase/mods" element={<ASEModManager />} />
+            <Route path="ase/config" element={<ASEConfigEditor />} />
+            <Route path="ase/clusters" element={<ASEClusterManager />} />
+            <Route path="ase/backups" element={<ASEBackups />} />
+            <Route path="ase/autosaves" element={<ASEAutoSaves />} />
+            <Route path="ase/logs" element={<ASELogsConsole />} />
+            <Route path="ase/rcon" element={<ASERconConsole />} />
+            <Route path="ase/scheduler" element={<ASEScheduler />} />
+            <Route path="ase/hardware" element={<ASEHardware />} />
+            <Route path="ase/files" element={<ASEFileManager />} />
+            <Route path="ase/settings" element={<ASESettings />} />
+            <Route path="ase/discord" element={<ASEDiscordBot />} />
+            <Route path="ase/profile-sync" element={<ASEProfileSync />} />
+            <Route path="ase/players" element={<ASEPlayerManager />} />
+            <Route path="ase/tools/ai" element={<ASEAIAssistant />} />
+            <Route path="ase/tools/advanced" element={<ASEAdvancedPage />} />
+            <Route path="ase/tools/plugins" element={<ASEPluginManager />} />
+            <Route path="ase/tools/tribe-logs" element={<ASETribeLogViewer />} />
+            <Route path="ase/tools/upnp" element={<ASEUPnPPanel />} />
+            <Route path="ase/tools/organization" element={<ASEServerOrganization />} />
+            <Route path="ase/tools/boost" element={<ASEBoostManager />} />
+            <Route path="ase/tools/chat-translator" element={<ChatTranslator />} />
+        </Route>
+    )
+);
+
 function App() {
     const [appState, setAppState] = useState<'welcome' | 'app'>('welcome');
 
@@ -111,68 +180,7 @@ function App() {
 
     return (
         <>
-            <BrowserRouter>
-                <ErrorBoundary>
-                    <Suspense fallback={<PageLoader />}>
-                        <Routes>
-                            <Route path="/" element={<AppLayout />}>
-                                <Route index element={<IndexRedirect />} />
-                                <Route path="dashboard" element={<Dashboard />} />
-                                <Route path="servers" element={<ServerManager />} />
-                                <Route path="mods" element={<ModManager />} />
-                                <Route path="config" element={<ConfigEditor />} />
-                                <Route path="clusters" element={<ClusterManager />} />
-                                <Route path="backups" element={<Backups />} />
-                                <Route path="autosaves" element={<AutoSaves />} />
-                                <Route path="rcon" element={<RconConsole />} />
-                                <Route path="scheduler" element={<Scheduler />} />
-                                <Route path="logs" element={<LogsConsole />} />
-                                <Route path="tools/advanced" element={<AdvancedPage />} />
-                                <Route path="tools/discord" element={<DiscordBot />} />
-                                <Route path="tools/discord-control" element={<DiscordControlPanel />} />
-                                <Route path="tools/plugins" element={<PluginManager />} />
-                                <Route path="tools/chat-translator" element={<ChatTranslator />} />
-                                <Route path="tools/combat-metrics" element={<CombatMetrics />} />
-                                <Route path="tools/files" element={<FileManager />} />
-                                <Route path="tools/ai" element={<AIAssistant />} />
-                                <Route path="tools/tribe-logs" element={<TribeLogViewer />} />
-                                <Route path="tools/upnp" element={<UPnPPanel />} />
-                                <Route path="tools/organization" element={<ServerOrganization />} />
-                                <Route path="tools/boost" element={<BoostManager />} />
-                                <Route path="hardware" element={<Hardware />} />
-                                <Route path="wiki" element={<Wiki />} />
-                                <Route path="settings" element={<Settings />} />
-
-                                {/* ASE Module Routes */}
-                                <Route path="ase/dashboard" element={<ASEDashboard />} />
-                                <Route path="ase/servers" element={<ASEServerManager />} />
-                                <Route path="ase/mods" element={<ASEModManager />} />
-                                <Route path="ase/config" element={<ASEConfigEditor />} />
-                                <Route path="ase/clusters" element={<ASEClusterManager />} />
-                                <Route path="ase/backups" element={<ASEBackups />} />
-                                <Route path="ase/autosaves" element={<ASEAutoSaves />} />
-                                <Route path="ase/logs" element={<ASELogsConsole />} />
-                                <Route path="ase/rcon" element={<ASERconConsole />} />
-                                <Route path="ase/scheduler" element={<ASEScheduler />} />
-                                <Route path="ase/hardware" element={<ASEHardware />} />
-                                <Route path="ase/files" element={<ASEFileManager />} />
-                                <Route path="ase/settings" element={<ASESettings />} />
-                                <Route path="ase/discord" element={<ASEDiscordBot />} />
-                                <Route path="ase/profile-sync" element={<ASEProfileSync />} />
-                                <Route path="ase/players" element={<ASEPlayerManager />} />
-                                 <Route path="ase/tools/ai" element={<ASEAIAssistant />} />
-                                 <Route path="ase/tools/advanced" element={<ASEAdvancedPage />} />
-                                 <Route path="ase/tools/plugins" element={<ASEPluginManager />} />
-                                 <Route path="ase/tools/tribe-logs" element={<ASETribeLogViewer />} />
-                                 <Route path="ase/tools/upnp" element={<ASEUPnPPanel />} />
-                                 <Route path="ase/tools/organization" element={<ASEServerOrganization />} />
-                                 <Route path="ase/tools/boost" element={<ASEBoostManager />} />
-                                 <Route path="ase/tools/chat-translator" element={<ChatTranslator />} />
-                            </Route>
-                        </Routes>
-                    </Suspense>
-                </ErrorBoundary>
-            </BrowserRouter>
+            <RouterProvider router={router} />
             <UpdateChecker />
             <DonationAlert />
         </>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { useBlocker } from 'react-router-dom';
 import { Save, Key, Lock, CheckCircle, AlertCircle, ExternalLink, RefreshCw, Download, Clock, History, Undo2, Globe, Trash2, Bot, Cloud, FolderOpen, FileText, Search, Copy, Check, Terminal, X, Cpu } from 'lucide-react';
 import { getSetting, setSetting, getAllServers } from '../utils/tauri';
 import toast from 'react-hot-toast';
@@ -38,6 +39,15 @@ export default function Settings() {
     const [showSteamKey, setShowSteamKey] = useState(false);
     const [nvidiaApiKey, setNvidiaApiKey] = useState('');
     const [showNvidiaKey, setShowNvidiaKey] = useState(false);
+
+    // AI Provider state (NVIDIA cloud vs. local LM Studio)
+    const [aiProvider, setAiProvider] = useState<'nvidia' | 'lmstudio'>('nvidia');
+    const [lmStudioBaseUrl, setLmStudioBaseUrl] = useState('http://localhost:1234/v1');
+    const [lmStudioModel, setLmStudioModel] = useState('');
+    const [lmStudioApiKey, setLmStudioApiKey] = useState('');
+    const [showLmStudioKey, setShowLmStudioKey] = useState(false);
+    const [lmStudioModels, setLmStudioModels] = useState<string[]>([]);
+    const [lmStudioProbing, setLmStudioProbing] = useState(false);
     const [currentVersion, setCurrentVersion] = useState<string>('');
     const [startupTimeout, setStartupTimeout] = useState('1800');
 
@@ -135,7 +145,8 @@ export default function Settings() {
         try {
             const [
                 curseforgeKey, steamKey, timeout, nvidiaKey,
-                gasEnabled, gbDelay, minTray, maxCrash, timeWindow, winShortcut, headless, ucf, csp
+                gasEnabled, gbDelay, minTray, maxCrash, timeWindow, winShortcut, headless, ucf, csp,
+                aiProviderVal, lmBaseUrl, lmModel, lmApiKey
             ] = await Promise.all([
                 getSetting('curseforge_api_key'),
                 getSetting('steam_api_key'),
@@ -149,12 +160,20 @@ export default function Settings() {
                 getSetting('windows_startup_shortcut'),
                 getSetting('silent_headless_startup'),
                 getSetting('user_config_folder'),
-                getSetting('custom_steamcmd_path')
+                getSetting('custom_steamcmd_path'),
+                getSetting('ai_provider'),
+                getSetting('lmstudio_base_url'),
+                getSetting('lmstudio_model'),
+                getSetting('lmstudio_api_key')
             ]);
             if (curseforgeKey) setCurseforgeApiKey(curseforgeKey);
             if (steamKey) setSteamApiKey(steamKey);
             if (timeout) setStartupTimeout(timeout);
             if (nvidiaKey) setNvidiaApiKey(nvidiaKey);
+            if (aiProviderVal === 'lmstudio' || aiProviderVal === 'nvidia') setAiProvider(aiProviderVal);
+            if (lmBaseUrl) setLmStudioBaseUrl(lmBaseUrl);
+            if (lmModel) setLmStudioModel(lmModel);
+            if (lmApiKey) setLmStudioApiKey(lmApiKey);
             
             setGlobalAutoStartEnabled(gasEnabled === 'true');
             setGlobalBootDelay(gbDelay || '0');
@@ -189,6 +208,45 @@ export default function Settings() {
             if (s.length > 0 && !selectedServerId) setSelectedServerId(s[0].id);
         }).catch(console.error);
     }, []);
+
+    // ── Unsaved-changes guard ──────────────────────────────────────────
+    // Snapshot of the fields that are only persisted via the Save button.
+    // (AI provider + LM Studio fields autosave on change, so they're excluded.)
+    const persistedSnapshot = () => JSON.stringify([
+        curseforgeApiKey, steamApiKey, nvidiaApiKey, startupTimeout,
+        globalAutoStartEnabled, globalBootDelay, startMinimizedToTray,
+        loopPreventionMaxCrashes, loopPreventionTimeWindowMins,
+        windowsStartupShortcut, silentHeadlessStartup, userConfigFolder, customSteamcmdPath,
+    ]);
+    const baselineRef = useRef<string>('');
+
+    // Capture the baseline once the initial load has populated state.
+    useEffect(() => {
+        if (!isLoading) baselineRef.current = persistedSnapshot();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isLoading]);
+
+    const isDirty = !isLoading && baselineRef.current !== '' && baselineRef.current !== persistedSnapshot();
+
+    // Block in-app navigation away from Settings while there are unsaved changes.
+    const blocker = useBlocker(() => isDirty);
+
+    // Warn on window close / reload while dirty.
+    useEffect(() => {
+        const handler = (e: BeforeUnloadEvent) => {
+            if (isDirty) {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        };
+        window.addEventListener('beforeunload', handler);
+        return () => window.removeEventListener('beforeunload', handler);
+    }, [isDirty]);
+
+    const handleSaveAndLeave = async () => {
+        const ok = await handleSave();
+        if (ok) blocker.proceed?.();
+    };
 
     const openUrl = async (url: string) => {
         try {
@@ -297,6 +355,46 @@ export default function Settings() {
         toast.success('Version entry removed from history');
     };
 
+    // Provider switching persists immediately so it takes effect without
+    // needing the global Save button (backend reads these settings live).
+    const handleSelectProvider = async (provider: 'nvidia' | 'lmstudio') => {
+        setAiProvider(provider);
+        try {
+            await setSetting('ai_provider', provider);
+        } catch (err) {
+            console.error('Failed to persist AI provider:', err);
+            toast.error('Failed to switch provider');
+        }
+    };
+
+    const handleProbeLmStudio = async () => {
+        setLmStudioProbing(true);
+        try {
+            // Persist the key first so the backend uses it for the probe request.
+            await setSetting('lmstudio_api_key', lmStudioApiKey);
+            const models = await invoke<string[]>('lmstudio_list_models', { baseUrl: lmStudioBaseUrl });
+            setLmStudioModels(models);
+            // Persist URL (and provider) now so a successful probe is immediately usable.
+            await setSetting('lmstudio_base_url', lmStudioBaseUrl);
+            await setSetting('ai_provider', 'lmstudio');
+            if (models.length === 0) {
+                toast('Connected, but no model is loaded in LM Studio.', { icon: '⚠️' });
+            } else {
+                toast.success(`Found ${models.length} model(s)`);
+                // Auto-select and persist the loaded model if none chosen yet
+                if (!lmStudioModel) {
+                    setLmStudioModel(models[0]);
+                    await setSetting('lmstudio_model', models[0]);
+                }
+            }
+        } catch (err) {
+            toast.error(typeof err === 'string' ? err : 'Failed to reach LM Studio');
+            setLmStudioModels([]);
+        } finally {
+            setLmStudioProbing(false);
+        }
+    };
+
     const handleSave = async () => {
         setIsSaving(true);
         try {
@@ -305,6 +403,10 @@ export default function Settings() {
                 setSetting('steam_api_key', steamApiKey),
                 setSetting('startup_timeout', startupTimeout),
                 setSetting('nvidia_api_key', nvidiaApiKey),
+                setSetting('ai_provider', aiProvider),
+                setSetting('lmstudio_base_url', lmStudioBaseUrl),
+                setSetting('lmstudio_model', lmStudioModel),
+                setSetting('lmstudio_api_key', lmStudioApiKey),
                 setSetting('global_auto_start_enabled', globalAutoStartEnabled ? 'true' : 'false'),
                 setSetting('global_boot_delay', globalBootDelay),
                 setSetting('start_minimized_to_tray', startMinimizedToTray ? 'true' : 'false'),
@@ -338,10 +440,13 @@ export default function Settings() {
                 toast.error("Failed to sync OS startup tasks. Run as Administrator if creating Scheduler task.");
             }
 
+            baselineRef.current = persistedSnapshot();
             toast.success(t('settings.saved'));
+            return true;
         } catch (error) {
             console.error('Failed to save settings:', error);
             toast.error(t('settings.saveFailed'));
+            return false;
         } finally {
             setIsSaving(false);
         }
@@ -783,6 +888,165 @@ export default function Settings() {
                             )}
                         </div>
                     </div>
+
+                    {/* AI Provider Selector */}
+                    <div className="glass-panel rounded-2xl p-8">
+                        <div className="flex items-start space-x-4 mb-6">
+                            <div className="p-3 bg-cyan-500/10 rounded-xl border border-cyan-500/20">
+                                <Cpu className="w-6 h-6 text-cyan-400" />
+                            </div>
+                            <div className="flex-1">
+                                <h2 className="text-2xl font-bold text-white mb-2">{t('settings.aiProvider.title', 'AI Provider')}</h2>
+                                <p className="text-slate-400">
+                                    {t('settings.aiProvider.description', 'Choose between NVIDIA cloud models or a local LM Studio server running your own loaded model.')}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <button
+                                onClick={() => handleSelectProvider('nvidia')}
+                                className={cn(
+                                    "text-left p-5 rounded-xl border transition-all",
+                                    aiProvider === 'nvidia'
+                                        ? "bg-emerald-500/10 border-emerald-500/40 ring-1 ring-emerald-500/30"
+                                        : "bg-slate-800/40 border-slate-700 hover:border-slate-600"
+                                )}
+                            >
+                                <div className="flex items-center gap-2 mb-1">
+                                    <Bot className="w-4 h-4 text-emerald-400" />
+                                    <span className="font-semibold text-white">{t('settings.aiProvider.nvidia', 'NVIDIA Cloud')}</span>
+                                    {aiProvider === 'nvidia' && <CheckCircle className="w-4 h-4 text-emerald-400 ml-auto" />}
+                                </div>
+                                <p className="text-xs text-slate-400">{t('settings.aiProvider.nvidiaDesc', 'Hosted NIM models. Requires an API key.')}</p>
+                            </button>
+
+                            <button
+                                onClick={() => handleSelectProvider('lmstudio')}
+                                className={cn(
+                                    "text-left p-5 rounded-xl border transition-all",
+                                    aiProvider === 'lmstudio'
+                                        ? "bg-cyan-500/10 border-cyan-500/40 ring-1 ring-cyan-500/30"
+                                        : "bg-slate-800/40 border-slate-700 hover:border-slate-600"
+                                )}
+                            >
+                                <div className="flex items-center gap-2 mb-1">
+                                    <Cpu className="w-4 h-4 text-cyan-400" />
+                                    <span className="font-semibold text-white">{t('settings.aiProvider.lmstudio', 'LM Studio (Local)')}</span>
+                                    {aiProvider === 'lmstudio' && <CheckCircle className="w-4 h-4 text-cyan-400 ml-auto" />}
+                                </div>
+                                <p className="text-xs text-slate-400">{t('settings.aiProvider.lmstudioDesc', 'Your own loaded model, offline & private.')}</p>
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* LM Studio Configuration */}
+                    {aiProvider === 'lmstudio' && (
+                        <div className="glass-panel rounded-2xl p-8">
+                            <div className="flex items-start space-x-4 mb-6">
+                                <div className="p-3 bg-cyan-500/10 rounded-xl border border-cyan-500/20">
+                                    <Terminal className="w-6 h-6 text-cyan-400" />
+                                </div>
+                                <div className="flex-1">
+                                    <h2 className="text-2xl font-bold text-white mb-2">{t('settings.lmStudio.title', 'LM Studio Endpoint')}</h2>
+                                    <p className="text-slate-400">
+                                        {t('settings.lmStudio.description', 'Point Infinity AI at a local OpenAI-compatible server and pick the loaded model.')}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div className="space-y-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-slate-300 mb-2">
+                                        {t('settings.lmStudio.baseUrl', 'Server Base URL')}
+                                    </label>
+                                    <div className="relative">
+                                        <Globe className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" />
+                                        <input
+                                            type="text"
+                                            value={lmStudioBaseUrl}
+                                            onChange={(e) => setLmStudioBaseUrl(e.target.value)}
+                                            onBlur={() => setSetting('lmstudio_base_url', lmStudioBaseUrl).catch(() => {})}
+                                            placeholder="http://localhost:1234/v1"
+                                            className="w-full pl-12 pr-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 transition-all font-mono"
+                                        />
+                                    </div>
+                                    <p className="text-xs text-slate-500 mt-2">
+                                        {t('settings.lmStudio.baseUrlHint', "In LM Studio: Developer tab → start the server. Default is http://localhost:1234/v1.")}
+                                    </p>
+                                </div>
+
+                                <div>
+                                    <label className="block text-sm font-medium text-slate-300 mb-2">
+                                        {t('settings.lmStudio.apiKey', 'API Token')} <span className="text-slate-500 font-normal">({t('common.optional', 'optional')})</span>
+                                    </label>
+                                    <div className="relative">
+                                        <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-500" />
+                                        <input
+                                            type={showLmStudioKey ? 'text' : 'password'}
+                                            value={lmStudioApiKey}
+                                            onChange={(e) => setLmStudioApiKey(e.target.value)}
+                                            onBlur={() => setSetting('lmstudio_api_key', lmStudioApiKey).catch(() => {})}
+                                            placeholder={t('settings.lmStudio.apiKeyPlaceholder', 'Leave blank for a default local server')}
+                                            className="w-full pl-12 pr-14 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 transition-all font-mono"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowLmStudioKey(!showLmStudioKey)}
+                                            className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400 hover:text-white transition-colors text-sm"
+                                        >
+                                            {showLmStudioKey ? t('common.hide') : t('common.show')}
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-slate-500 mt-2">
+                                        {t('settings.lmStudio.apiKeyHint', 'Only needed if your server enforces auth (e.g. a remote endpoint or a proxy in front of LM Studio).')}
+                                    </p>
+                                </div>
+
+                                <div>
+                                    <label className="block text-sm font-medium text-slate-300 mb-2">
+                                        {t('settings.lmStudio.model', 'Loaded Model')}
+                                    </label>
+                                    <div className="flex gap-2">
+                                        <input
+                                            type="text"
+                                            value={lmStudioModel}
+                                            onChange={(e) => setLmStudioModel(e.target.value)}
+                                            onBlur={() => setSetting('lmstudio_model', lmStudioModel).catch(() => {})}
+                                            placeholder="qwen3.5-4b-uncensored-hauhaucs-aggressive"
+                                            list="lmstudio-models"
+                                            className="flex-1 px-4 py-3 bg-slate-800/50 border border-slate-700 rounded-xl text-white placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-cyan-500 transition-all font-mono"
+                                        />
+                                        <datalist id="lmstudio-models">
+                                            {lmStudioModels.map((m) => <option key={m} value={m} />)}
+                                        </datalist>
+                                        <button
+                                            onClick={handleProbeLmStudio}
+                                            disabled={lmStudioProbing}
+                                            className="flex items-center gap-2 px-4 py-3 bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white rounded-xl transition-colors shadow-lg shadow-cyan-500/20 whitespace-nowrap"
+                                        >
+                                            <RefreshCw className={cn("w-4 h-4", lmStudioProbing && "animate-spin")} />
+                                            <span>{t('settings.lmStudio.detect', 'Detect')}</span>
+                                        </button>
+                                    </div>
+                                    <p className="text-xs text-slate-500 mt-2">
+                                        {t('settings.lmStudio.modelHint', 'Type the model id or click Detect to list models loaded in LM Studio. Leave blank to use the currently loaded one.')}
+                                    </p>
+                                </div>
+
+                                {lmStudioModels.length > 0 && (
+                                    <div className="bg-cyan-500/10 border border-cyan-500/20 rounded-xl p-4">
+                                        <div className="flex items-center space-x-2">
+                                            <CheckCircle className="w-5 h-5 text-cyan-400" />
+                                            <span className="text-cyan-400 font-medium">
+                                                {t('settings.lmStudio.connected', 'Connected — {{count}} model(s) available', { count: lmStudioModels.length })}
+                                            </span>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    )}
 
                     {/* NVIDIA AI API Key */}
                     <div className="glass-panel rounded-2xl p-8">
@@ -1289,6 +1553,44 @@ export default function Settings() {
             ) : null}
 
             {/* Log Viewer Modal */}
+            {blocker.state === 'blocked' && createPortal(
+                <div className="fixed inset-0 z-[110] flex items-center justify-center p-4 bg-slate-950/80 backdrop-blur-sm animate-in fade-in duration-200">
+                    <div className="relative w-full max-w-md flex flex-col bg-slate-900/95 border border-slate-800 rounded-2xl shadow-2xl overflow-hidden backdrop-blur-md animate-in zoom-in-95 duration-200">
+                        <div className="p-6 border-b border-slate-800">
+                            <h3 className="text-xl font-bold text-white flex items-center gap-2">
+                                <AlertCircle className="w-5 h-5 text-amber-400" />
+                                {t('settings.unsaved.title', 'Unsaved changes')}
+                            </h3>
+                            <p className="text-sm text-slate-400 mt-2">
+                                {t('settings.unsaved.body', 'You have unsaved settings. Leaving this page will discard them.')}
+                            </p>
+                        </div>
+                        <div className="flex flex-col sm:flex-row gap-2 p-4 bg-slate-900/40">
+                            <button
+                                onClick={() => blocker.reset?.()}
+                                className="flex-1 px-4 py-2.5 rounded-xl bg-slate-800 hover:bg-slate-700 border border-slate-700 text-white font-medium transition-colors"
+                            >
+                                {t('settings.unsaved.stay', 'Stay')}
+                            </button>
+                            <button
+                                onClick={() => blocker.proceed?.()}
+                                className="flex-1 px-4 py-2.5 rounded-xl bg-red-600/90 hover:bg-red-500 text-white font-medium transition-colors"
+                            >
+                                {t('settings.unsaved.discard', 'Leave without saving')}
+                            </button>
+                            <button
+                                onClick={handleSaveAndLeave}
+                                disabled={isSaving}
+                                className="flex-1 px-4 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white font-medium transition-colors"
+                            >
+                                {isSaving ? t('common.saving', 'Saving…') : t('settings.unsaved.saveLeave', 'Save & leave')}
+                            </button>
+                        </div>
+                    </div>
+                </div>,
+                document.body
+            )}
+
             {isViewLogOpen && createPortal(
                 <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-slate-950/80 backdrop-blur-sm animate-in fade-in duration-200">
                     <div className="relative w-full max-w-5xl h-[85vh] flex flex-col bg-slate-900/90 border border-slate-800 rounded-2xl shadow-2xl overflow-hidden backdrop-blur-md animate-in zoom-in-95 duration-200">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -141,6 +141,11 @@ export default function Settings() {
     };
 
 
+    /**
+     * Loads all persisted settings from the backend DB (API keys, AI provider +
+     * LM Studio config, startup/recovery options, path overrides) plus local
+     * update settings, and populates the corresponding form state.
+     */
     async function loadSettings() {
         try {
             const [
@@ -210,8 +215,12 @@ export default function Settings() {
     }, []);
 
     // ── Unsaved-changes guard ──────────────────────────────────────────
-    // Snapshot of the fields that are only persisted via the Save button.
-    // (AI provider + LM Studio fields autosave on change, so they're excluded.)
+    /**
+     * Serializes the fields that are only persisted via the Save button into a
+     * stable string, used to detect unsaved edits by comparing against a
+     * baseline. AI provider + LM Studio fields autosave on change, so they are
+     * deliberately excluded here.
+     */
     const persistedSnapshot = () => JSON.stringify([
         curseforgeApiKey, steamApiKey, nvidiaApiKey, startupTimeout,
         globalAutoStartEnabled, globalBootDelay, startMinimizedToTray,
@@ -243,6 +252,10 @@ export default function Settings() {
         return () => window.removeEventListener('beforeunload', handler);
     }, [isDirty]);
 
+    /**
+     * Save & leave action for the unsaved-changes dialog: persists all settings
+     * and only proceeds with the blocked navigation if the save succeeded.
+     */
     const handleSaveAndLeave = async () => {
         const ok = await handleSave();
         if (ok) blocker.proceed?.();
@@ -355,8 +368,11 @@ export default function Settings() {
         toast.success('Version entry removed from history');
     };
 
-    // Provider switching persists immediately so it takes effect without
-    // needing the global Save button (backend reads these settings live).
+    /**
+     * Switches the active AI provider (NVIDIA cloud vs. local LM Studio) and
+     * persists the choice immediately, so it takes effect without the global
+     * Save button — the Rust backend reads `ai_provider` live on each request.
+     */
     const handleSelectProvider = async (provider: 'nvidia' | 'lmstudio') => {
         setAiProvider(provider);
         try {
@@ -367,6 +383,12 @@ export default function Settings() {
         }
     };
 
+    /**
+     * Probes the configured LM Studio server for its loaded models via the
+     * `lmstudio_list_models` command. Persists the API key, base URL and provider
+     * first so a successful probe is immediately usable, auto-selects the first
+     * loaded model when none is chosen, and surfaces connection errors as toasts.
+     */
     const handleProbeLmStudio = async () => {
         setLmStudioProbing(true);
         try {
@@ -395,6 +417,12 @@ export default function Settings() {
         }
     };
 
+    /**
+     * Persists all Save-button-backed settings to the backend DB, synchronizes
+     * the OS startup hooks (registry run key / Task Scheduler) with the current
+     * options, and resets the unsaved-changes baseline.
+     * @returns `true` if the save succeeded, `false` otherwise.
+     */
     const handleSave = async () => {
         setIsSaving(true);
         try {


### PR DESCRIPTION
## Add LM Studio provider, unsaved-changes guard, and SteamCMD custom-path fix

### AI Provider: LM Studio support
Adds a local **LM Studio** (OpenAI-compatible) provider alongside the existing NVIDIA cloud backend.

- New **AI Provider** selector in Settings (NVIDIA Cloud / LM Studio).
- Configurable server base URL (default `http://localhost:1234/v1`), custom loaded model name (e.g. `qwen3.5-4b-uncensored-...`), and optional API token.
- **Detect** button lists models loaded in LM Studio (`lmstudio_list_models` command) and auto-fills the model.
- Provider/URL/model/token persist immediately on change so switching takes effect without a full save.
- Backend `ai_chat` / `ai_chat_stream` refactored to resolve the active provider's endpoint, auth header (sent only when a key is set), and model. No more hardcoded NVIDIA endpoint.

### Unsaved-changes guard on Settings
- Migrated the app router from `<BrowserRouter>` to `createBrowserRouter` + `<RouterProvider>` (same route tree) to enable navigation blocking.
- Leaving Settings with unsaved edits now prompts: **Stay / Leave without saving / Save & leave**. Also warns on window close/reload.

### Fix: custom SteamCMD path
- Server installer now self-heals — if `steamcmd.exe` is missing from the configured (custom) folder, it downloads and installs SteamCMD there instead of failing with "SteamCMD not found."
- Path resolver normalizes the setting: strips quotes and, if pointed directly at `steamcmd.exe`, uses the parent folder.

### Notes
- Default provider stays `nvidia`; existing users are unaffected.
- New settings keys: `ai_provider`, `lmstudio_base_url`, `lmstudio_model`, `lmstudio_api_key`.

---

Want a shorter version, or a title-only line?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for switching between NVIDIA cloud AI and local LM Studio providers.
  * Added LM Studio model detection and automatic model selection.
  * Settings now warn about unsaved changes before navigation or closing.
  * SteamCMD can now be installed automatically when missing during server setup.

* **Bug Fixes**
  * Improved handling of custom SteamCMD paths, including quoted paths and executable locations.
  * AI requests now use the selected provider, endpoint, model, and optional API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->